### PR TITLE
Two crash fixes for graphics and camera

### DIFF
--- a/hw3d/Camera.cpp
+++ b/hw3d/Camera.cpp
@@ -22,7 +22,7 @@ void Camera::SpawnControlWindow() noexcept
 	if( ImGui::Begin( "Camera" ) )
 	{
 		ImGui::Text( "Position" );
-		ImGui::SliderFloat( "R",&r,0.0f,80.0f,"%.1f" );
+		ImGui::SliderFloat( "R",&r, FLT_EPSILON,80.0f,"%.1f" );
 		ImGui::SliderAngle( "Theta",&theta,-180.0f,180.0f );
 		ImGui::SliderAngle( "Phi",&phi,-89.0f,89.0f );
 		ImGui::Text( "Orientation" );
@@ -35,6 +35,7 @@ void Camera::SpawnControlWindow() noexcept
 		}
 	}
 	ImGui::End();
+	if( r <= 0 ) r = FLT_EPSILON;
 }
 
 void Camera::Reset() noexcept

--- a/hw3d/Graphics.cpp
+++ b/hw3d/Graphics.cpp
@@ -17,8 +17,13 @@ namespace dx = DirectX;
 
 Graphics::Graphics( HWND hWnd )
 {
+	// for checking results of d3d functions
+	HRESULT hr;
+
 	RECT rcTemp;
-	GetWindowRect( hWnd, &rcTemp );
+	if( !GetWindowRect( hWnd, &rcTemp ) ) {
+		GFX_EXCEPT( __HRESULT_FROM_WIN32( GetLastError() ) );
+	}
 
 	DXGI_SWAP_CHAIN_DESC sd = {};
 	sd.BufferDesc.Width = 0;
@@ -41,9 +46,6 @@ Graphics::Graphics( HWND hWnd )
 #ifndef NDEBUG
 	swapCreateFlags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
-
-	// for checking results of d3d functions
-	HRESULT hr;
 
 	// create device and front/back buffers, and swap chain and rendering context
 	GFX_THROW_INFO( D3D11CreateDeviceAndSwapChain(

--- a/hw3d/Graphics.cpp
+++ b/hw3d/Graphics.cpp
@@ -17,6 +17,9 @@ namespace dx = DirectX;
 
 Graphics::Graphics( HWND hWnd )
 {
+	RECT rcTemp;
+	GetWindowRect( hWnd, &rcTemp );
+
 	DXGI_SWAP_CHAIN_DESC sd = {};
 	sd.BufferDesc.Width = 0;
 	sd.BufferDesc.Height = 0;
@@ -77,8 +80,8 @@ Graphics::Graphics( HWND hWnd )
 	// create depth stensil texture
 	wrl::ComPtr<ID3D11Texture2D> pDepthStencil;
 	D3D11_TEXTURE2D_DESC descDepth = {};
-	descDepth.Width = 800u;
-	descDepth.Height = 600u;
+	descDepth.Width = rcTemp.right;
+	descDepth.Height = rcTemp.bottom;
 	descDepth.MipLevels = 1u;
 	descDepth.ArraySize = 1u;
 	descDepth.Format = DXGI_FORMAT_D32_FLOAT;
@@ -102,8 +105,8 @@ Graphics::Graphics( HWND hWnd )
 	   
 	// configure viewport
 	D3D11_VIEWPORT vp;
-	vp.Width = 800.0f;
-	vp.Height = 600.0f;
+	vp.Width = rcTemp.right;
+	vp.Height = rcTemp.bottom;
 	vp.MinDepth = 0.0f;
 	vp.MaxDepth = 1.0f;
 	vp.TopLeftX = 0.0f;


### PR DESCRIPTION
Camera crashes when r = 0. Graphics crashes when Window size doesn't match.