### PR TITLE
Fixing compilation errors on VS 2022

### DIFF
--- a/hw3d/ShadowMappingPass.h
+++ b/hw3d/ShadowMappingPass.h
@@ -71,7 +71,8 @@ namespace Rgph
 		{
 			using namespace DirectX;
 
-			const auto pos = XMLoadFloat3( &pShadowCamera->GetPos() );
+			const auto foo = pShadowCamera->GetPos();
+			const auto pos = XMLoadFloat3( &foo );
 
 			gfx.SetProjection( XMLoadFloat4x4( &projection ) );
 			for( size_t i = 0; i < 6; i++ )

--- a/hw3d/WindowsMessageMap.h
+++ b/hw3d/WindowsMessageMap.h
@@ -18,6 +18,7 @@
 *	along with The Chili Direct3D Engine.  If not, see <http://www.gnu.org/licenses/>.    *
 ******************************************************************************************/
 #pragma once
+#include <string>
 #include <unordered_map>
 #include "ChiliWin.h"
 

--- a/hw3d/hw3d.vcxproj
+++ b/hw3d/hw3d.vcxproj
@@ -20,13 +20,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Hey @planetchili, thank you so much for the great tutorial. To make the hw3d project compile on the latest VS 2022, some minor fixes are necessary. Feel free to pull if you're interested.